### PR TITLE
Use crates.io for `astroport` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,9 @@ version = 3
 
 [[package]]
 name = "astroport"
-version = "0.3.1"
-source = "git+https://github.com/astroport-fi/astroport-core.git?tag=v1.0.0#05bfb278302d462c355e47ed67566a8a97f417dd"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b56c6d8a5a14a5f569a3473a962ed1d12bfec2a19ef43584c86aae5667bdeaa8"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 0.8.1",

--- a/contracts/mars-oracle/Cargo.toml
+++ b/contracts/mars-oracle/Cargo.toml
@@ -36,7 +36,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 thiserror = "1.0.23"
 
-astroport = { git = "https://github.com/astroport-fi/astroport-core.git", tag = "v1.0.0" }
+astroport = "1.0"
 
 [dev-dependencies]
 cosmwasm-schema = "0.16.2"

--- a/contracts/mars-protocol-rewards-collector/Cargo.toml
+++ b/contracts/mars-protocol-rewards-collector/Cargo.toml
@@ -32,7 +32,7 @@ schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0.23"
 
-astroport = { git = "https://github.com/astroport-fi/astroport-core.git", tag = "v1.0.0" }
+astroport = "1.0"
 
 [dev-dependencies]
 cosmwasm-schema = { version = "0.16.2" }

--- a/contracts/mars-staking/Cargo.toml
+++ b/contracts/mars-staking/Cargo.toml
@@ -33,7 +33,7 @@ schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0.23"
 
-astroport = { git = "https://github.com/astroport-fi/astroport-core.git", tag = "v1.0.0" }
+astroport = "1.0"
 
 [dev-dependencies]
 cosmwasm-schema = "0.16.2"

--- a/packages/mars-core/Cargo.toml
+++ b/packages/mars-core/Cargo.toml
@@ -24,7 +24,7 @@ schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0.23"
 
-astroport = { git = "https://github.com/astroport-fi/astroport-core.git", tag = "v1.0.0" }
+astroport = "1.0"
 
 [profile.release]
 overflow-checks = true


### PR DESCRIPTION
This PR changes the import of `astroport` dependency in `Cargo.toml` as follows:

```diff
[dependencies]
- astroport = { git = "https://github.com/astroport-fi/astroport-core.git", tag = "v1.0.0" }
+ astroport = "1.0"
```

Since Astroport is available on crates.io, we should use crates.io over Github links.