### PR TITLE
Chainlink integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "mars-core"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "astroport",
  "basset",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "mars-oracle"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "astroport",
  "cosmwasm-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,7 @@ dependencies = [
  "cw2",
  "cw20 0.9.1",
  "cw20-base",
+ "proxy-ocr2",
  "schemars",
  "serde",
  "terra-cosmwasm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "access-controller"
+version = "1.0.0"
+source = "git+https://github.com/smartcontractkit/chainlink-terra#b8c708f5957b83a789e339dc330c78b9202e0d37"
+dependencies = [
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.9.1",
+ "cw2",
+ "owned",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "astroport"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,6 +50,17 @@ dependencies = [
  "serde",
  "terra-cosmwasm",
  "thiserror",
+]
+
+[[package]]
+name = "blake2"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -148,6 +174,16 @@ dependencies = [
  "rand_core 0.6.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -281,6 +317,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "deviation-flagging-validator"
+version = "1.0.0"
+source = "git+https://github.com/smartcontractkit/chainlink-terra#b8c708f5957b83a789e339dc330c78b9202e0d37"
+dependencies = [
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.9.1",
+ "cw2",
+ "flags",
+ "owned",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +400,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "flags"
+version = "1.0.0"
+source = "git+https://github.com/smartcontractkit/chainlink-terra#b8c708f5957b83a789e339dc330c78b9202e0d37"
+dependencies = [
+ "access-controller",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.9.1",
+ "cw2",
+ "owned",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "forward_ref"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,7 +476,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.11.1",
  "digest",
 ]
 
@@ -518,6 +586,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 0.9.1",
  "mars-core",
+ "proxy-ocr2",
  "schemars",
  "serde",
  "terra-cosmwasm",
@@ -627,10 +696,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "ocr2"
+version = "1.0.0"
+source = "git+https://github.com/smartcontractkit/chainlink-terra#b8c708f5957b83a789e339dc330c78b9202e0d37"
+dependencies = [
+ "access-controller",
+ "blake2",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.9.1",
+ "cw2",
+ "cw20 0.9.1",
+ "deviation-flagging-validator",
+ "hex",
+ "owned",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "owned"
+version = "1.0.0"
+source = "git+https://github.com/smartcontractkit/chainlink-terra#b8c708f5957b83a789e339dc330c78b9202e0d37"
+dependencies = [
+ "cosmwasm-std",
+ "cw-storage-plus 0.9.1",
+ "schemars",
+ "serde",
+ "thiserror",
+]
 
 [[package]]
 name = "pkcs8"
@@ -649,6 +750,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "proxy-ocr2"
+version = "1.0.0"
+source = "git+https://github.com/smartcontractkit/chainlink-terra#b8c708f5957b83a789e339dc330c78b9202e0d37"
+dependencies = [
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.9.1",
+ "cw2",
+ "ocr2",
+ "owned",
+ "schemars",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/contracts/mars-oracle/Cargo.toml
+++ b/contracts/mars-oracle/Cargo.toml
@@ -32,7 +32,7 @@ cw-storage-plus = "0.9.0"
 cosmwasm-std = "0.16.2"
 
 schemars = "0.8.1"
-serde = { version = "1.0.136", default-features = false, features = ["derive"] }
+serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 thiserror = "1.0.23"
 

--- a/contracts/mars-oracle/Cargo.toml
+++ b/contracts/mars-oracle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mars-oracle"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
   "Spike Spiegel <spikeonmars@protonmail.com>",
   "larry_0x <larry@delphidigital.io>"
@@ -23,7 +23,7 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-mars-core = { path = "../../packages/mars-core", version = "1.0.1" }
+mars-core = { path = "../../packages/mars-core", version = "1.0.2" }
 
 terra-cosmwasm = "2.2.0"
 

--- a/contracts/mars-oracle/Cargo.toml
+++ b/contracts/mars-oracle/Cargo.toml
@@ -32,11 +32,13 @@ cw-storage-plus = "0.9.0"
 cosmwasm-std = "0.16.2"
 
 schemars = "0.8.1"
-serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+serde = { version = "1.0.136", default-features = false, features = ["derive"] }
 
 thiserror = "1.0.23"
 
 astroport = "1.0"
+
+chainlink-terra = { git = "https://github.com/smartcontractkit/chainlink-terra", package = "proxy-ocr2", version = "1.0.0", default-features = false, features = ["library"] }
 
 [dev-dependencies]
 cosmwasm-schema = "0.16.2"

--- a/contracts/mars-oracle/src/error.rs
+++ b/contracts/mars-oracle/src/error.rs
@@ -24,6 +24,9 @@ pub enum ContractError {
 
     #[error("Invalid pair")]
     InvalidPair {},
+
+    #[error("Chainlink price is too old")]
+    ChainlinkPriceTooOld {},
 }
 
 impl From<ContractError> for StdError {

--- a/contracts/mars-oracle/src/error.rs
+++ b/contracts/mars-oracle/src/error.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::{OverflowError, StdError};
 use mars_core::error::MarsError;
+use mars_core::math::decimal::Decimal;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -25,8 +26,17 @@ pub enum ContractError {
     #[error("Invalid pair")]
     InvalidPair {},
 
-    #[error("Chainlink price exceeds the allowable price deviation from Astroport TWAP")]
-    ChainlinkPriceExceedsAllowableDeviationPercentage {},
+    #[error(
+        "Chainlink price exceeds the allowable price deviation from Astroport TWAP \
+        (chainlink_price: {chainlink_price:?}, \
+        astroport_twap_price: {astroport_twap_price:?}, \
+        deviation_percentage: {deviation_percentage:?})"
+    )]
+    ChainlinkPriceExceedsAllowableDeviationPercentage {
+        chainlink_price: Decimal,
+        astroport_twap_price: Decimal,
+        deviation_percentage: Decimal,
+    },
 }
 
 impl From<ContractError> for StdError {

--- a/contracts/mars-oracle/src/error.rs
+++ b/contracts/mars-oracle/src/error.rs
@@ -25,9 +25,6 @@ pub enum ContractError {
     #[error("Invalid pair")]
     InvalidPair {},
 
-    #[error("Chainlink price is too old")]
-    ChainlinkPriceTooOld {},
-
     #[error("Chainlink price exceeds the allowable price deviation from Astroport TWAP")]
     ChainlinkPriceExceedsAllowableDeviationPercentage {},
 }

--- a/contracts/mars-oracle/src/error.rs
+++ b/contracts/mars-oracle/src/error.rs
@@ -27,6 +27,9 @@ pub enum ContractError {
 
     #[error("Chainlink price is too old")]
     ChainlinkPriceTooOld {},
+
+    #[error("Chainlink price exceeds the allowable price deviation from Astroport TWAP")]
+    ChainlinkPriceExceedsAllowableDeviationPercentage {},
 }
 
 impl From<ContractError> for StdError {

--- a/packages/mars-core/Cargo.toml
+++ b/packages/mars-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mars-core"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Spike Spiegel <spikeonmars@protonmail.com>"]
 edition = "2018"
 description = "Mars is a fully automated, on-chain credit protocol built on Terra and governed by a decentralised community of users and developers"

--- a/packages/mars-core/Cargo.toml
+++ b/packages/mars-core/Cargo.toml
@@ -35,5 +35,7 @@ astroport = "1.0"
 
 basset = { git = "https://github.com/lidofinance/lido-terra-contracts", tag = "v1.0.2" }
 
+chainlink-terra = { git = "https://github.com/smartcontractkit/chainlink-terra", package = "proxy-ocr2", version = "1.0.0", default-features = false, features = ["library"] }
+
 [profile.release]
 overflow-checks = true

--- a/packages/mars-core/src/oracle.rs
+++ b/packages/mars-core/src/oracle.rs
@@ -52,6 +52,11 @@ pub enum PriceSource<A> {
     },
     /// stLuna price calculated from stLuna/Luna exchange rate from Lido hub contract and Luna price from current price source
     Stluna { hub_address: A },
+    /// Chainlink price quoted in UST
+    Chainlink {
+        /// Chainlink’s contract for the asset
+        contract_addr: A,
+    },
 }
 
 impl<A> fmt::Display for PriceSource<A> {
@@ -63,6 +68,7 @@ impl<A> fmt::Display for PriceSource<A> {
             PriceSource::AstroportTwap { .. } => "astroport_twap",
             PriceSource::AstroportLiquidityToken { .. } => "astroport_liquidity_token",
             PriceSource::Stluna { .. } => "stluna",
+            PriceSource::Chainlink { .. } => "chainlink",
         };
         write!(f, "{}", label)
     }
@@ -99,6 +105,9 @@ impl PriceSourceUnchecked {
             }
             PriceSourceUnchecked::Stluna { hub_address } => PriceSourceChecked::Stluna {
                 hub_address: api.addr_validate(hub_address)?,
+            },
+            PriceSourceUnchecked::Chainlink { contract_addr } => PriceSourceChecked::Chainlink {
+                contract_addr: api.addr_validate(contract_addr)?,
             },
         })
     }

--- a/packages/mars-core/src/oracle.rs
+++ b/packages/mars-core/src/oracle.rs
@@ -56,6 +56,9 @@ pub enum PriceSource<A> {
     Chainlink {
         /// Chainlink’s contract for the asset
         contract_addr: A,
+        /// Defines how many seconds can pass from current timestamp to last observations
+        /// for the price to be considered up-to-date
+        validity_period: u64,
     },
 }
 
@@ -106,8 +109,12 @@ impl PriceSourceUnchecked {
             PriceSourceUnchecked::Stluna { hub_address } => PriceSourceChecked::Stluna {
                 hub_address: api.addr_validate(hub_address)?,
             },
-            PriceSourceUnchecked::Chainlink { contract_addr } => PriceSourceChecked::Chainlink {
+            PriceSourceUnchecked::Chainlink {
+                contract_addr,
+                validity_period,
+            } => PriceSourceChecked::Chainlink {
                 contract_addr: api.addr_validate(contract_addr)?,
+                validity_period: *validity_period,
             },
         })
     }

--- a/packages/mars-core/src/testing/chainlink_querier.rs
+++ b/packages/mars-core/src/testing/chainlink_querier.rs
@@ -1,0 +1,42 @@
+use std::collections::HashMap;
+
+use cosmwasm_std::{to_binary, Addr, QuerierResult};
+
+use chainlink_terra::state::Round;
+
+#[derive(Default)]
+pub struct ChainlinkQuerier {
+    /// maps asset contract address to decimals
+    pub assets_decimals: HashMap<Addr, u8>,
+    /// maps asset contract address to latest price (latest round data)
+    pub assets_latest_round_data: HashMap<Addr, Round>,
+}
+
+impl ChainlinkQuerier {
+    pub fn handle_query(
+        &self,
+        contract_addr: &Addr,
+        query: chainlink_terra::msg::QueryMsg,
+    ) -> QuerierResult {
+        match query {
+            chainlink_terra::msg::QueryMsg::Decimals {} => {
+                match self.assets_decimals.get(&Addr::unchecked(contract_addr)) {
+                    Some(decimals) => Ok(to_binary(decimals).into()).into(),
+                    None => panic!("[mock]: no decimals for the contract"),
+                }
+            }
+
+            chainlink_terra::msg::QueryMsg::LatestRoundData {} => {
+                match self
+                    .assets_latest_round_data
+                    .get(&Addr::unchecked(contract_addr))
+                {
+                    Some(round) => Ok(to_binary(round).into()).into(),
+                    None => panic!("[mock]: no price (latest round data) for the contract"),
+                }
+            }
+
+            _ => panic!("[mock]: unimplemented"),
+        }
+    }
+}

--- a/packages/mars-core/src/testing/mod.rs
+++ b/packages/mars-core/src/testing/mod.rs
@@ -1,6 +1,7 @@
 mod astroport_factory_querier;
 mod astroport_pair_querier;
 mod basset_querier;
+mod chainlink_querier;
 mod cw20_querier;
 /// cosmwasm_std::testing overrides and custom test helpers
 mod helpers;


### PR DESCRIPTION
Astroport Anchored Chainlink (normalized to UST):

1. System queries the Chainlink price.
    1. If the Chainlink price is USD denominated, the system converts the price to UST using the Chainlink UST/USD price feed. The remaining UST denominated price is `Chainlink UST Price`.
2. System queries the `Astroport TWAP`.
3. System checks whether the `Astroport TWAP` falls within the `max_deviation` from the `Chainlink UST Price`. Specifically, the `Astroport TWAP` should fall within the following interval: `[Chainlink UST Price * (1 - max_deviation), Chainlink UST Price * (1 + max_deviation)]`
    1. If it doesn’t, the system is halted and the transaction doesn’t go through.
4. `max_deviation` = 15% initially for all pools, but could be adjusted by governance.

Chainlink Solo:

1. System queries the Chainlink price.
    1. If the Chainlink price is USD denominated, the system converts the price to UST using the Chainlink UST/USD price feed. The remaining UST denominated price is `Chainlink UST Price`.