### PR TITLE
Lunax price source.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.124"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "mars-address-provider"
@@ -573,12 +573,14 @@ name = "mars-oracle"
 version = "1.0.2"
 dependencies = [
  "astroport",
+ "basset",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.9.1",
  "mars-core",
  "schemars",
  "serde",
+ "staking",
  "terra-cosmwasm",
  "thiserror",
 ]
@@ -917,9 +919,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,24 @@
 version = 3
 
 [[package]]
+name = "airdrops-registry"
+version = "0.1.0"
+source = "git+https://github.com/stader-labs/stader-liquid-token?tag=v0.2.1#acf69c8cf02c7fc2baf39962c68c1555dc4c5916"
+dependencies = [
+ "cosmwasm-bignumber",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.8.1",
+ "cw2 0.9.1",
+ "cw20 0.8.1",
+ "schemars",
+ "serde",
+ "stader-utils",
+ "terra-cosmwasm",
+ "thiserror",
+]
+
+[[package]]
 name = "astroport"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +56,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bigint"
+version = "4.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0e8c8a600052b52482eff2cf4d810e462fdff1f656ac1ecb6232132a1ed7def"
+dependencies = [
+ "byteorder",
+ "crunchy 0.1.6",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +91,18 @@ name = "const-oid"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+
+[[package]]
+name = "cosmwasm-bignumber"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce94de6dd2b3d74cd8d9bc2bf5d6208ffed832ad946774ea9ed2a9ef7d95161f"
+dependencies = [
+ "bigint",
+ "cosmwasm-std",
+ "schemars",
+ "serde",
+]
 
 [[package]]
 name = "cosmwasm-crypto"
@@ -131,6 +171,12 @@ checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 
 [[package]]
 name = "crunchy"
@@ -221,6 +267,18 @@ dependencies = [
 
 [[package]]
 name = "cw2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d48454f96494aa1018556cd457977375cc8c57ef3e5c767cfa2ea5ec24b0258"
+dependencies = [
+ "cosmwasm-std",
+ "cw-storage-plus 0.8.1",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw2"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6380164fb236412ff43c7ca075d95847c6fa8c51b2d3a513c23127a0f2a8f6"
@@ -264,7 +322,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 0.9.1",
  "cw0 0.9.1",
- "cw2",
+ "cw2 0.9.1",
  "cw20 0.9.1",
  "schemars",
  "serde",
@@ -450,16 +508,17 @@ dependencies = [
 
 [[package]]
 name = "mars-core"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "astroport",
  "basset",
  "cosmwasm-std",
- "cw2",
+ "cw2 0.9.1",
  "cw20 0.9.1",
  "cw20-base",
  "schemars",
  "serde",
+ "staking",
  "terra-cosmwasm",
  "thiserror",
 ]
@@ -500,7 +559,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 0.9.1",
  "cw0 0.9.1",
- "cw2",
+ "cw2 0.9.1",
  "cw20 0.9.1",
  "cw20-base",
  "mars-core",
@@ -511,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "mars-oracle"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "astroport",
  "cosmwasm-schema",
@@ -617,7 +676,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 0.9.1",
  "cw0 0.9.1",
- "cw2",
+ "cw2 0.9.1",
  "cw20 0.9.1",
  "cw20-base",
  "mars-core",
@@ -676,6 +735,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom 0.2.6",
+]
+
+[[package]]
+name = "reward"
+version = "0.1.0"
+source = "git+https://github.com/stader-labs/stader-liquid-token?tag=v0.2.1#acf69c8cf02c7fc2baf39962c68c1555dc4c5916"
+dependencies = [
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.8.1",
+ "cw2 0.9.1",
+ "cw20 0.8.1",
+ "schemars",
+ "serde",
+ "stader-utils",
+ "terra-cosmwasm",
+ "thiserror",
 ]
 
 [[package]]
@@ -792,6 +868,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "stader-utils"
+version = "0.1.0"
+source = "git+https://github.com/stader-labs/stader-liquid-token?tag=v0.2.1#acf69c8cf02c7fc2baf39962c68c1555dc4c5916"
+dependencies = [
+ "cosmwasm-bignumber",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.8.1",
+ "cw20 0.8.1",
+ "schemars",
+ "serde",
+ "terra-cosmwasm",
+ "thiserror",
+]
+
+[[package]]
+name = "staking"
+version = "0.1.0"
+source = "git+https://github.com/stader-labs/stader-liquid-token?tag=v0.2.1#acf69c8cf02c7fc2baf39962c68c1555dc4c5916"
+dependencies = [
+ "airdrops-registry",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.8.1",
+ "cw2 0.8.1",
+ "cw20 0.9.1",
+ "cw20-base",
+ "reward",
+ "schemars",
+ "serde",
+ "stader-utils",
+ "terra-cosmwasm",
+ "thiserror",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,7 +970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f03af7ccf01dd611cc450a0d10dbc9b745770d096473e2faf0ca6e2d66d1e0"
 dependencies = [
  "byteorder",
- "crunchy",
+ "crunchy 0.2.2",
  "hex",
  "static_assertions",
 ]

--- a/contracts/mars-oracle/Cargo.toml
+++ b/contracts/mars-oracle/Cargo.toml
@@ -38,6 +38,10 @@ thiserror = "1.0.23"
 
 astroport = "1.0"
 
+basset = { git = "https://github.com/lidofinance/lido-terra-contracts", tag = "v1.0.2" }
+
+stader = { git = "https://github.com/stader-labs/stader-liquid-token", package = "staking", tag = "v0.2.1", features = ["library"] }
+
 [dev-dependencies]
 cosmwasm-schema = "0.16.2"
 

--- a/contracts/mars-oracle/Cargo.toml
+++ b/contracts/mars-oracle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mars-oracle"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
   "Spike Spiegel <spikeonmars@protonmail.com>",
   "larry_0x <larry@delphidigital.io>"
@@ -23,7 +23,7 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-mars-core = { path = "../../packages/mars-core", version = "1.0.1" }
+mars-core = { path = "../../packages/mars-core", version = "1.0.2" }
 
 terra-cosmwasm = "2.2.0"
 

--- a/contracts/mars-oracle/src/contract.rs
+++ b/contracts/mars-oracle/src/contract.rs
@@ -350,10 +350,8 @@ mod helpers {
             SimulationResponse,
         },
     };
-    use mars_core::basset::hub::{QueryMsg, StateResponse};
-    use mars_core::stader::msg::{
-        QueryMsg as StaderQueryMsg, QueryStateResponse as StaderStateResponse,
-    };
+    use basset::hub::{QueryMsg as BAssetQueryMsg, StateResponse as BAssetStateResponse};
+    use stader::msg::{QueryMsg as StaderQueryMsg, QueryStateResponse as StaderStateResponse};
 
     const PROBE_AMOUNT: Uint128 = Uint128::new(1_000_000);
 
@@ -467,10 +465,11 @@ mod helpers {
         querier: &QuerierWrapper,
         hub_address: &Addr,
     ) -> StdResult<Decimal> {
-        let response: StateResponse = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
-            contract_addr: hub_address.to_string(),
-            msg: to_binary(&QueryMsg::State {})?,
-        }))?;
+        let response: BAssetStateResponse =
+            querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+                contract_addr: hub_address.to_string(),
+                msg: to_binary(&BAssetQueryMsg::State {})?,
+            }))?;
         Ok(response.stluna_exchange_rate.into())
     }
 
@@ -495,13 +494,13 @@ mod tests {
     use astroport::asset::{Asset as AstroportAsset, AssetInfo, PairInfo};
     use astroport::factory::PairType;
     use astroport::pair::{CumulativePricesResponse, SimulationResponse};
+    use basset::hub::StateResponse;
     use cosmwasm_std::testing::{mock_env, mock_info, MockApi, MockStorage};
     use cosmwasm_std::Decimal as StdDecimal;
     use cosmwasm_std::{from_binary, Addr, OwnedDeps};
-    use mars_core::basset::hub::StateResponse;
-    use mars_core::stader::msg::QueryStateResponse as StaderStateResponse;
-    use mars_core::stader::state::State as StaderState;
     use mars_core::testing::{mock_dependencies, mock_env_at_block_time, MarsMockQuerier};
+    use stader::msg::QueryStateResponse as StaderStateResponse;
+    use stader::state::State as StaderState;
 
     #[test]
     fn test_proper_initialization() {

--- a/contracts/mars-oracle/src/contract.rs
+++ b/contracts/mars-oracle/src/contract.rs
@@ -315,6 +315,18 @@ fn query_asset_price(
             let stluna_price = stluna_exchange_rate.checked_mul(luna_price)?;
             Ok(stluna_price)
         }
+
+        PriceSourceChecked::Lunax { staking_address } => {
+            let lunax_exchange_rate = query_lunax_exchange_rate(&deps.querier, &staking_address)?;
+
+            let luna_asset = Asset::Native {
+                denom: "uluna".to_string(),
+            };
+            let luna_price = query_asset_price(deps, env, luna_asset.get_reference())?;
+
+            let lunax_price = lunax_exchange_rate.checked_mul(luna_price)?;
+            Ok(lunax_price)
+        }
     }
 }
 
@@ -339,6 +351,9 @@ mod helpers {
         },
     };
     use mars_core::basset::hub::{QueryMsg, StateResponse};
+    use mars_core::stader::msg::{
+        QueryMsg as StaderQueryMsg, QueryStateResponse as StaderStateResponse,
+    };
 
     const PROBE_AMOUNT: Uint128 = Uint128::new(1_000_000);
 
@@ -458,6 +473,18 @@ mod helpers {
         }))?;
         Ok(response.stluna_exchange_rate.into())
     }
+
+    pub fn query_lunax_exchange_rate(
+        querier: &QuerierWrapper,
+        staking_address: &Addr,
+    ) -> StdResult<Decimal> {
+        let response: StaderStateResponse =
+            querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+                contract_addr: staking_address.to_string(),
+                msg: to_binary(&StaderQueryMsg::State {})?,
+            }))?;
+        Ok(response.state.exchange_rate.into())
+    }
 }
 
 // TESTS
@@ -472,6 +499,8 @@ mod tests {
     use cosmwasm_std::Decimal as StdDecimal;
     use cosmwasm_std::{from_binary, Addr, OwnedDeps};
     use mars_core::basset::hub::StateResponse;
+    use mars_core::stader::msg::QueryStateResponse as StaderStateResponse;
+    use mars_core::stader::state::State as StaderState;
     use mars_core::testing::{mock_dependencies, mock_env_at_block_time, MarsMockQuerier};
 
     #[test]
@@ -712,6 +741,34 @@ mod tests {
             price_source,
             PriceSourceChecked::Stluna {
                 hub_address: Addr::unchecked("stluna_hub_addr")
+            }
+        );
+    }
+
+    #[test]
+    fn test_set_asset_lunax() {
+        let mut deps = th_setup();
+        let info = mock_info("owner", &[]);
+
+        let asset = Asset::Cw20 {
+            contract_addr: String::from("lunax_token"),
+        };
+        let reference = asset.get_reference();
+        let msg = ExecuteMsg::SetAsset {
+            asset: asset,
+            price_source: PriceSourceUnchecked::Lunax {
+                staking_address: "lunax_staking_addr".to_string(),
+            },
+        };
+        execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
+
+        let price_source = PRICE_SOURCES
+            .load(&deps.storage, reference.as_slice())
+            .unwrap();
+        assert_eq!(
+            price_source,
+            PriceSourceChecked::Lunax {
+                staking_address: Addr::unchecked("lunax_staking_addr")
             }
         );
     }
@@ -1225,6 +1282,77 @@ mod tests {
 
         // stLuna/USD = stLuna/Luna * Luna/USD
         assert_eq!(price, Decimal::from_ratio(1034_u128, 10_u128));
+    }
+
+    #[test]
+    fn test_query_asset_price_lunax() {
+        let mut deps = th_setup();
+
+        // Setup Luna native price source
+        let asset = Asset::Native {
+            denom: "uluna".to_string(),
+        };
+        let asset_reference = asset.get_reference();
+
+        deps.querier.set_native_exchange_rates(
+            "uluna".to_string(),
+            &[("uusd".to_string(), Decimal::from_ratio(94_u128, 1_u128))],
+        );
+
+        PRICE_SOURCES
+            .save(
+                &mut deps.storage,
+                asset_reference.as_slice(),
+                &PriceSourceChecked::Native {
+                    denom: "uluna".to_string(),
+                },
+            )
+            .unwrap();
+
+        // Setup LunaX (LunaX / Luna) price source
+        let asset = Asset::Cw20 {
+            contract_addr: String::from("lunax_token"),
+        };
+        let asset_reference = asset.get_reference();
+
+        PRICE_SOURCES
+            .save(
+                &mut deps.storage,
+                asset_reference.as_slice(),
+                &PriceSourceChecked::Lunax {
+                    staking_address: Addr::unchecked("lunax_staking_addr"),
+                },
+            )
+            .unwrap();
+
+        deps.querier.set_stader_state_response(StaderStateResponse {
+            state: StaderState {
+                total_staked: Default::default(),
+                exchange_rate: StdDecimal::from_ratio(112_u128, 100_u128), // 1 lunax = 1.12 luna
+                last_reconciled_batch_id: 0,
+                current_undelegation_batch_id: 0,
+                last_undelegation_time: Default::default(),
+                last_swap_time: Default::default(),
+                last_reinvest_time: Default::default(),
+                validators: vec![],
+                reconciled_funds_to_withdraw: Default::default(),
+            },
+        });
+
+        let price: Decimal = from_binary(
+            &query(
+                deps.as_ref(),
+                mock_env(),
+                QueryMsg::AssetPriceByReference {
+                    asset_reference: asset_reference.clone(),
+                },
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        // LunaX/USD = LunaX/Luna * Luna/USD
+        assert_eq!(price, Decimal::from_ratio(10528_u128, 100_u128));
     }
 
     // TEST_HELPERS

--- a/packages/mars-core/Cargo.toml
+++ b/packages/mars-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mars-core"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Spike Spiegel <spikeonmars@protonmail.com>"]
 edition = "2018"
 description = "Mars is a fully automated, on-chain credit protocol built on Terra and governed by a decentralised community of users and developers"
@@ -34,6 +34,8 @@ thiserror = "1.0.23"
 astroport = "1.0"
 
 basset = { git = "https://github.com/lidofinance/lido-terra-contracts", tag = "v1.0.2" }
+
+stader = { git = "https://github.com/stader-labs/stader-liquid-token", package = "staking", tag = "v0.2.1", features = ["library"] }
 
 [profile.release]
 overflow-checks = true

--- a/packages/mars-core/src/lib.rs
+++ b/packages/mars-core/src/lib.rs
@@ -25,7 +25,3 @@ pub mod tax;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod testing;
-
-// Reimport to be used by mars contracts
-pub use basset;
-pub use stader;

--- a/packages/mars-core/src/lib.rs
+++ b/packages/mars-core/src/lib.rs
@@ -28,3 +28,4 @@ pub mod testing;
 
 // Reimport to be used by mars contracts
 pub use basset;
+pub use stader;

--- a/packages/mars-core/src/oracle.rs
+++ b/packages/mars-core/src/oracle.rs
@@ -52,6 +52,8 @@ pub enum PriceSource<A> {
     },
     /// stLuna price calculated from stLuna/Luna exchange rate from Lido hub contract and Luna price from current price source
     Stluna { hub_address: A },
+    /// Lunax price calculated from Lunax/Luna exchange rate from Stader staking contract and Luna price from current price source
+    Lunax { staking_address: A },
 }
 
 impl<A> fmt::Display for PriceSource<A> {
@@ -63,6 +65,7 @@ impl<A> fmt::Display for PriceSource<A> {
             PriceSource::AstroportTwap { .. } => "astroport_twap",
             PriceSource::AstroportLiquidityToken { .. } => "astroport_liquidity_token",
             PriceSource::Stluna { .. } => "stluna",
+            PriceSource::Lunax { .. } => "lunax",
         };
         write!(f, "{}", label)
     }
@@ -99,6 +102,9 @@ impl PriceSourceUnchecked {
             }
             PriceSourceUnchecked::Stluna { hub_address } => PriceSourceChecked::Stluna {
                 hub_address: api.addr_validate(hub_address)?,
+            },
+            PriceSourceUnchecked::Lunax { staking_address } => PriceSourceChecked::Lunax {
+                staking_address: api.addr_validate(staking_address)?,
             },
         })
     }

--- a/packages/mars-core/src/testing/mod.rs
+++ b/packages/mars-core/src/testing/mod.rs
@@ -10,6 +10,7 @@ mod mock_address_provider;
 mod mocks;
 mod native_querier;
 mod oracle_querier;
+mod stader_querier;
 mod staking_querier;
 mod vesting_querier;
 mod xmars_querier;

--- a/packages/mars-core/src/testing/stader_querier.rs
+++ b/packages/mars-core/src/testing/stader_querier.rs
@@ -1,0 +1,22 @@
+use cosmwasm_std::{to_binary, Binary, ContractResult, QuerierResult};
+
+use stader::msg::{QueryMsg, QueryStateResponse};
+
+#[derive(Clone, Default)]
+pub struct StaderQuerier {
+    pub state_response: Option<QueryStateResponse>,
+}
+
+impl StaderQuerier {
+    pub fn handle_query(&self, request: &QueryMsg) -> QuerierResult {
+        let ret: ContractResult<Binary> = match &request {
+            QueryMsg::State {} => match self.state_response.as_ref() {
+                Some(resp) => to_binary(resp).into(),
+                None => panic!("[mock]: StateResponse is not provided for query"),
+            },
+            _ => Err("[mock]: Unsupported stader query").into(),
+        };
+
+        Ok(ret).into()
+    }
+}


### PR DESCRIPTION
LunaX Oracle (non-standard implementation):

1. System queries the LunaX/Luna exchange rate from the Stader staking contract (https://github.com/stader-labs/stader-liquid-token/blob/main/contracts/staking/src/contract.rs#L1228).

2. System queries the Luna/UST price from current price source (native oracle).

3. System calculates the LunaX/UST price as follows: LunaX/UST price = LunaX/Luna exchange rate * Luna/UST price.