### PR TITLE
Shut down Red Bank, refund users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,12 +624,10 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 0.9.1",
  "cw20 0.9.1",
- "cw20-base",
  "mars-core",
  "mars-red-bank",
  "schemars",
  "serde",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mars-red-bank-closure"
+version = "1.0.0"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.9.1",
+ "cw20 0.9.1",
+ "cw20-base",
+ "mars-core",
+ "mars-red-bank",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "mars-safety-fund"
 version = "1.0.0"
 dependencies = [

--- a/contracts/mars-red-bank-closure/Cargo.toml
+++ b/contracts/mars-red-bank-closure/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "mars-red-bank-closure"
+version = "1.0.0"
+authors = ["larry <larry@delphidigital.io>"]
+edition = "2018"
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+mars-core = { path = "../../packages/mars-core", version = "1.0.0" }
+
+mars-red-bank = { path = "../mars-red-bank", version = "1.0.0", features = ["library"] }
+
+cw20 = "0.9.0"
+cw20-base = { version = "0.9.0", features = ["library"] }
+cw-storage-plus = "0.9.0"
+
+cosmwasm-std = "0.16.2"
+
+schemars = "0.8.1"
+serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+thiserror = "1.0.23"
+
+[dev-dependencies]
+cosmwasm-schema = "0.16.2"

--- a/contracts/mars-red-bank-closure/Cargo.toml
+++ b/contracts/mars-red-bank-closure/Cargo.toml
@@ -23,18 +23,15 @@ library = []
 
 [dependencies]
 mars-core = { path = "../../packages/mars-core", version = "1.0.0" }
-
 mars-red-bank = { path = "../mars-red-bank", version = "1.0.0", features = ["library"] }
 
 cw20 = "0.9.0"
-cw20-base = { version = "0.9.0", features = ["library"] }
 cw-storage-plus = "0.9.0"
 
 cosmwasm-std = "0.16.2"
 
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-thiserror = "1.0.23"
 
 [dev-dependencies]
 cosmwasm-schema = "0.16.2"

--- a/contracts/mars-red-bank-closure/src/contract.rs
+++ b/contracts/mars-red-bank-closure/src/contract.rs
@@ -86,7 +86,7 @@ pub fn refund(deps: DepsMut, env: Env, asset: Asset) -> StdResult<Response> {
 
         // event log
         events.push(
-            Event::new("mars_red_bank/refund")
+            Event::new("mars_red_bank/refunded")
                 .add_attribute("user", &owner_addr)
                 .add_attribute("asset", &asset_label)
                 .add_attribute("asset_amount", amount_to_refund)

--- a/contracts/mars-red-bank-closure/src/contract.rs
+++ b/contracts/mars-red-bank-closure/src/contract.rs
@@ -51,7 +51,6 @@ pub fn refund(deps: DepsMut, env: Env, asset: Asset) -> StdResult<Response> {
     // - the amount of this asset held by Red Bank
     // - the maToken's total supply
     // - grab the first 10 holders of the asset's corresponding maToken and their respective balances
-    // since all debts have been repaid, this amount should be sufficient to refund all users
     let mut total_amount_to_refund =
         get_asset_balance(&deps.querier, &asset, &env.contract.address)?;
     let mut ma_token_supply =

--- a/contracts/mars-red-bank-closure/src/contract.rs
+++ b/contracts/mars-red-bank-closure/src/contract.rs
@@ -3,9 +3,9 @@ use cosmwasm_std::{
     Response, StdError, StdResult, WasmMsg,
 };
 
-use cw20::Cw20ExecuteMsg;
 use mars_core::asset::Asset;
 use mars_core::helpers::cw20_get_total_supply;
+use mars_core::ma_token::msg::ExecuteMsg as MaTokenExecuteMsg;
 
 use mars_red_bank::state::MARKETS;
 
@@ -70,8 +70,8 @@ pub fn refund(deps: DepsMut, env: Env, asset: Asset) -> StdResult<Response> {
         // burn maToken
         msgs.push(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: market.ma_token_address.to_string(),
-            msg: to_binary(&Cw20ExecuteMsg::BurnFrom {
-                owner: owner_addr.to_string(),
+            msg: to_binary(&MaTokenExecuteMsg::Burn {
+                user: owner_addr.to_string(),
                 amount: balance,
             })?,
             funds: vec![],

--- a/contracts/mars-red-bank-closure/src/contract.rs
+++ b/contracts/mars-red-bank-closure/src/contract.rs
@@ -1,0 +1,119 @@
+use cosmwasm_std::{
+    entry_point, to_binary, Binary, CosmosMsg, Deps, DepsMut, Empty, Env, Event, MessageInfo,
+    Response, StdError, StdResult, WasmMsg,
+};
+
+use cw20::Cw20ExecuteMsg;
+use mars_core::asset::Asset;
+use mars_core::helpers::{cw20_get_balance, cw20_get_total_supply};
+
+use mars_red_bank::state::MARKETS;
+
+use crate::helpers::{build_transfer_asset_msg, cw20_get_owners_balances};
+use crate::msg::ExecuteMsg;
+
+#[entry_point]
+pub fn instantiate(
+    _deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: Empty,
+) -> StdResult<Response> {
+    Err(StdError::generic_err("`instantiate` is not implemented"))
+}
+
+#[entry_point]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    _info: MessageInfo,
+    msg: ExecuteMsg,
+) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::Refund { asset } => refund(deps, env, asset),
+    }
+}
+
+pub fn refund(deps: DepsMut, env: Env, asset: Asset) -> StdResult<Response> {
+    let (asset_label, asset_ref, _) = asset.get_attributes();
+    let market = MARKETS.load(deps.storage, &asset_ref)?;
+
+    // to initiate the refund, all borrowings of the specified asset must have been repaid. that is,
+    // `debt_total_scaled` parameter in its `Market` must be zero
+    if !market.debt_total_scaled.is_zero() {
+        return Err(StdError::generic_err(format!(
+            "`debt_total_scaled` must be zero before a refund a be initiated; current value: {}",
+            market.debt_total_scaled
+        )));
+    }
+
+    // query the amount of this asset held by Red Bank
+    // since all debts have been repaid, this amount should be sufficient to refund all users
+    let mut total_amount_to_refund = match &asset {
+        Asset::Cw20 { contract_addr } => cw20_get_balance(
+            &deps.querier,
+            deps.api.addr_validate(contract_addr)?,
+            env.contract.address,
+        )?,
+        Asset::Native { denom } => {
+            let balance_query = deps.querier.query_balance(env.contract.address, denom)?;
+            balance_query.amount
+        }
+    };
+
+    // query the maToken's total supply
+    let mut ma_token_supply =
+        cw20_get_total_supply(&deps.querier, market.ma_token_address.clone())?;
+
+    // grab the first 10 holders of the asset's corresponding maToken and their respective balances
+    let owners_balances =
+        cw20_get_owners_balances(&deps.querier, deps.api, &market.ma_token_address)?;
+
+    // for each maToken owner, calculate how much tokens they should be refunded; create the messages
+    // to burn their maToken and tranfer funds
+    let mut msgs: Vec<CosmosMsg> = vec![];
+    let mut events: Vec<Event> = vec![];
+    for (owner_addr, balance) in owners_balances {
+        let amount_to_refund = total_amount_to_refund.multiply_ratio(balance, ma_token_supply);
+        total_amount_to_refund -= amount_to_refund;
+        ma_token_supply -= balance;
+
+        // burn maToken
+        msgs.push(CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: market.ma_token_address.to_string(),
+            msg: to_binary(&Cw20ExecuteMsg::BurnFrom {
+                owner: owner_addr.to_string(),
+                amount: balance,
+            })?,
+            funds: vec![],
+        }));
+
+        // refund asset
+        msgs.push(build_transfer_asset_msg(
+            &asset,
+            amount_to_refund,
+            &owner_addr,
+        )?);
+
+        // event log
+        events.push(
+            Event::new("mars_red_bank/refund")
+                .add_attribute("user", &owner_addr)
+                .add_attribute("asset", &asset_label)
+                .add_attribute("asset_amount", amount_to_refund)
+                .add_attribute("matoken_burned", balance),
+        )
+    }
+
+    Ok(Response::new().add_messages(msgs).add_events(events))
+}
+
+#[entry_point]
+pub fn query(_deps: Deps, _env: Env, _msg: Empty) -> StdResult<Binary> {
+    Err(StdError::generic_err("`query` is not implemented"))
+}
+
+#[entry_point]
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: Empty) -> StdResult<Response> {
+    Ok(Response::new())
+}

--- a/contracts/mars-red-bank-closure/src/contract_tests.rs
+++ b/contracts/mars-red-bank-closure/src/contract_tests.rs
@@ -1,0 +1,166 @@
+use cosmwasm_std::testing::{mock_env, mock_info, MockApi, MockStorage};
+use cosmwasm_std::{
+    coin, to_binary, Addr, BankMsg, CosmosMsg, OwnedDeps, ReplyOn, SubMsg, Uint128, WasmMsg,
+};
+use cw20::Cw20ExecuteMsg;
+
+use mars_core::asset::Asset;
+use mars_core::testing::{mock_dependencies, MarsMockQuerier};
+use mars_red_bank::state::MARKETS;
+use mars_red_bank::Market;
+
+use crate::contract::execute;
+use crate::msg::ExecuteMsg;
+
+fn uusd() -> Asset {
+    Asset::Native {
+        denom: "uusd".to_string(),
+    }
+}
+
+// contract has 120 UST
+//
+// maUST:
+// total supply: 100
+// alice: 60
+// bob: 30
+// charlie: 10
+fn setup_test() -> OwnedDeps<MockStorage, MockApi, MarsMockQuerier> {
+    let mut deps = mock_dependencies(&[coin(120000000, "uusd")]);
+
+    deps.querier.set_cw20_balances(
+        Addr::unchecked("maUST"),
+        &[
+            (Addr::unchecked("alice"), Uint128::new(60000000)),
+            (Addr::unchecked("bob"), Uint128::new(30000000)),
+            (Addr::unchecked("charlie"), Uint128::new(10000000)),
+        ],
+    );
+    deps.querier
+        .set_cw20_total_supply(Addr::unchecked("maUST"), Uint128::new(100000000));
+
+    MARKETS
+        .save(
+            deps.as_mut().storage,
+            &uusd().get_reference(),
+            &Market {
+                ma_token_address: Addr::unchecked("maUST"),
+                debt_total_scaled: Uint128::zero(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    deps
+}
+
+#[test]
+fn refunding() {
+    let mut deps = setup_test();
+
+    // alice gets 120000000 * 60000000 / 100000000 = 72000000
+    // total_amount_to_refund = 120000000 - 72000000 = 48000000
+    // maUST total supply = 10000000 - 60000000 = 40000000
+    //
+    // bob gets 48000000 * 30000000 / 40000000 = 36000000
+    // total_amount_to_refund = 48000000 - 36000000 = 12000000
+    // maUST total supply = = 40000000 - 30000000 = 10000000
+    //
+    // charlie gets the rest 12000000 uusd
+    let res = execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info("admin", &[]),
+        ExecuteMsg::Refund { asset: uusd() },
+    )
+    .unwrap();
+
+    assert_eq!(res.messages.len(), 6);
+    assert_eq!(
+        res.messages[0],
+        SubMsg {
+            id: 0,
+            msg: CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: "maUST".to_string(),
+                msg: to_binary(&Cw20ExecuteMsg::BurnFrom {
+                    owner: "alice".to_string(),
+                    amount: Uint128::new(60000000)
+                })
+                .unwrap(),
+                funds: vec![]
+            }),
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        }
+    );
+    assert_eq!(
+        res.messages[1],
+        SubMsg {
+            id: 0,
+            msg: CosmosMsg::Bank(BankMsg::Send {
+                to_address: "alice".to_string(),
+                amount: vec![coin(72000000, "uusd")]
+            }),
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        }
+    );
+    assert_eq!(
+        res.messages[2],
+        SubMsg {
+            id: 0,
+            msg: CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: "maUST".to_string(),
+                msg: to_binary(&Cw20ExecuteMsg::BurnFrom {
+                    owner: "bob".to_string(),
+                    amount: Uint128::new(30000000)
+                })
+                .unwrap(),
+                funds: vec![]
+            }),
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        }
+    );
+    assert_eq!(
+        res.messages[3],
+        SubMsg {
+            id: 0,
+            msg: CosmosMsg::Bank(BankMsg::Send {
+                to_address: "bob".to_string(),
+                amount: vec![coin(36000000, "uusd")]
+            }),
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        }
+    );
+    assert_eq!(
+        res.messages[4],
+        SubMsg {
+            id: 0,
+            msg: CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: "maUST".to_string(),
+                msg: to_binary(&Cw20ExecuteMsg::BurnFrom {
+                    owner: "charlie".to_string(),
+                    amount: Uint128::new(10000000)
+                })
+                .unwrap(),
+                funds: vec![]
+            }),
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        }
+    );
+    assert_eq!(
+        res.messages[5],
+        SubMsg {
+            id: 0,
+            msg: CosmosMsg::Bank(BankMsg::Send {
+                to_address: "charlie".to_string(),
+                amount: vec![coin(12000000, "uusd")]
+            }),
+            gas_limit: None,
+            reply_on: ReplyOn::Never,
+        }
+    );
+}

--- a/contracts/mars-red-bank-closure/src/contract_tests.rs
+++ b/contracts/mars-red-bank-closure/src/contract_tests.rs
@@ -2,9 +2,9 @@ use cosmwasm_std::testing::{mock_env, mock_info, MockApi, MockStorage};
 use cosmwasm_std::{
     coin, to_binary, Addr, BankMsg, CosmosMsg, OwnedDeps, ReplyOn, SubMsg, Uint128, WasmMsg,
 };
-use cw20::Cw20ExecuteMsg;
 
 use mars_core::asset::Asset;
+use mars_core::ma_token::msg::ExecuteMsg as MaTokenExecuteMsg;
 use mars_core::testing::{mock_dependencies, MarsMockQuerier};
 use mars_red_bank::state::MARKETS;
 use mars_red_bank::Market;
@@ -82,8 +82,8 @@ fn refunding() {
             id: 0,
             msg: CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: "maUST".to_string(),
-                msg: to_binary(&Cw20ExecuteMsg::BurnFrom {
-                    owner: "alice".to_string(),
+                msg: to_binary(&MaTokenExecuteMsg::Burn {
+                    user: "alice".to_string(),
                     amount: Uint128::new(60000000)
                 })
                 .unwrap(),
@@ -111,8 +111,8 @@ fn refunding() {
             id: 0,
             msg: CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: "maUST".to_string(),
-                msg: to_binary(&Cw20ExecuteMsg::BurnFrom {
-                    owner: "bob".to_string(),
+                msg: to_binary(&MaTokenExecuteMsg::Burn {
+                    user: "bob".to_string(),
                     amount: Uint128::new(30000000)
                 })
                 .unwrap(),
@@ -140,8 +140,8 @@ fn refunding() {
             id: 0,
             msg: CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: "maUST".to_string(),
-                msg: to_binary(&Cw20ExecuteMsg::BurnFrom {
-                    owner: "charlie".to_string(),
+                msg: to_binary(&MaTokenExecuteMsg::Burn {
+                    user: "charlie".to_string(),
                     amount: Uint128::new(10000000)
                 })
                 .unwrap(),

--- a/contracts/mars-red-bank-closure/src/helpers.rs
+++ b/contracts/mars-red-bank-closure/src/helpers.rs
@@ -37,12 +37,35 @@ pub fn cw20_get_owners_balances(
         .collect::<StdResult<Vec<_>>>()
 }
 
+pub fn get_asset_balance<T: Into<String>>(
+    querier: &QuerierWrapper,
+    asset: &Asset,
+    account: T,
+) -> StdResult<Uint128> {
+    let balance = match &asset {
+        Asset::Cw20 { contract_addr } => {
+            let query: BalanceResponse = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+                contract_addr: contract_addr.clone(),
+                msg: to_binary(&Cw20QueryMsg::Balance {
+                    address: account.into(),
+                })?,
+            }))?;
+            query.balance
+        }
+        Asset::Native { denom } => {
+            let balance_query = querier.query_balance(account, denom)?;
+            balance_query.amount
+        }
+    };
+    Ok(balance)
+}
+
 pub fn build_transfer_asset_msg(
     asset: &Asset,
     amount: Uint128,
     recipient: &Addr,
 ) -> StdResult<CosmosMsg> {
-    Ok(match asset {
+    let msg = match asset {
         Asset::Cw20 { contract_addr } => CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: contract_addr.clone(),
             msg: to_binary(&Cw20ExecuteMsg::Transfer {
@@ -55,5 +78,6 @@ pub fn build_transfer_asset_msg(
             to_address: recipient.to_string(),
             amount: vec![coin(amount.u128(), denom)],
         }),
-    })
+    };
+    Ok(msg)
 }

--- a/contracts/mars-red-bank-closure/src/helpers.rs
+++ b/contracts/mars-red-bank-closure/src/helpers.rs
@@ -1,0 +1,59 @@
+use cosmwasm_std::{
+    coin, to_binary, Addr, Api, BankMsg, CosmosMsg, QuerierWrapper, QueryRequest, StdResult,
+    Uint128, WasmMsg, WasmQuery,
+};
+use cw20::{AllAccountsResponse, BalanceResponse, Cw20ExecuteMsg, Cw20QueryMsg};
+
+use mars_core::asset::Asset;
+
+/// Get the first 10 token owners and their respective token balances
+pub fn cw20_get_owners_balances(
+    querier: &QuerierWrapper,
+    api: &dyn Api,
+    token_addr: &Addr,
+) -> StdResult<Vec<(Addr, Uint128)>> {
+    let AllAccountsResponse { accounts } =
+        querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+            contract_addr: token_addr.to_string(),
+            msg: to_binary(&Cw20QueryMsg::AllAccounts {
+                start_after: None,
+                limit: Some(10),
+            })?,
+        }))?;
+
+    accounts
+        .iter()
+        .map(|acct| {
+            let acct_addr = api.addr_validate(acct)?;
+            let BalanceResponse { balance } =
+                querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+                    contract_addr: token_addr.to_string(),
+                    msg: to_binary(&Cw20QueryMsg::Balance {
+                        address: acct_addr.to_string(),
+                    })?,
+                }))?;
+            Ok((acct_addr, balance))
+        })
+        .collect::<StdResult<Vec<_>>>()
+}
+
+pub fn build_transfer_asset_msg(
+    asset: &Asset,
+    amount: Uint128,
+    recipient: &Addr,
+) -> StdResult<CosmosMsg> {
+    Ok(match asset {
+        Asset::Cw20 { contract_addr } => CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: contract_addr.clone(),
+            msg: to_binary(&Cw20ExecuteMsg::Transfer {
+                recipient: recipient.to_string(),
+                amount,
+            })?,
+            funds: vec![],
+        }),
+        Asset::Native { denom } => CosmosMsg::Bank(BankMsg::Send {
+            to_address: recipient.to_string(),
+            amount: vec![coin(amount.u128(), denom)],
+        }),
+    })
+}

--- a/contracts/mars-red-bank-closure/src/lib.rs
+++ b/contracts/mars-red-bank-closure/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod contract;
+pub mod helpers;
+pub mod msg;
+
+#[cfg(test)]
+mod contract_tests;

--- a/contracts/mars-red-bank-closure/src/msg.rs
+++ b/contracts/mars-red-bank-closure/src/msg.rs
@@ -1,0 +1,11 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use mars_core::asset::Asset;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    /// Refund the first 10 users of a specific asset; call this function repeatedly to refund all users
+    Refund { asset: Asset },
+}


### PR DESCRIPTION
Procedure for shutting down Red Bank and refund users:
* Owner disables borrowings and repays
* A third party pays back all users' debts using `on_behalf_of` parameter
* Admin migrates Red Bank to `mars-red-bank-closure` binary
* Admin invokes `refund` execute msg by specifying `asset` to be UST. This refunds the first 10 maUST holders (ordered alphabetically based on account addresses) of their UST deposit and burn their maUST. Invoke this method repeatedly to refund all users of UST and burn all maUST
* Admin does the same for maLUNA and maANC